### PR TITLE
feat: Add Foxglove Studio integration launch file

### DIFF
--- a/launch_ROS2/odin1_foxglove.launch.py
+++ b/launch_ROS2/odin1_foxglove.launch.py
@@ -1,0 +1,76 @@
+
+import os
+import yaml 
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    # Get package directory
+    package_dir = get_package_share_directory('odin_ros_driver')
+    
+    # Declare configuration parameter
+    config_file_arg = DeclareLaunchArgument(
+        'config_file',
+        default_value=os.path.join(package_dir, 'config', 'control_command.yaml'),
+        description='Path to the control config YAML file'
+    )
+    
+    # Create main node
+    host_sdk_node = Node(
+        package='odin_ros_driver',
+        executable='host_sdk_sample',
+        name='host_sdk_sample',
+        output='screen',
+        parameters=[{
+            'config_file': LaunchConfiguration('config_file')
+        }]
+    )
+
+    # Load parameters for pcd2depth node
+    # Note: This logic follows the pattern in odin1_ros2.launch.py
+    # Ideally this should use the launch argument, but we need to load the file to pass dict as params
+    pcd2depth_config_path = os.path.join(package_dir, 'config', 'control_command.yaml')
+    with open(pcd2depth_config_path, 'r') as f:
+        pcd2depth_params = yaml.safe_load(f) 
+    
+    pcd2depth_calib_path = os.path.join(package_dir, 'config', 'calib.yaml')
+    pcd2depth_params['calib_file_path'] = pcd2depth_calib_path 
+    
+    pcd2depth_node = Node(
+        package='odin_ros_driver',
+        executable='pcd2depth_ros2_node',  
+        name='pcd2depth_ros2_node',
+        output='screen',
+        parameters=[pcd2depth_params]
+    )
+
+    # Foxglove Bridge Node
+    # This node allows Foxglove Studio to connect to the ROS 2 system
+    # Requires: sudo apt install ros-<distro>-foxglove-bridge
+    foxglove_bridge_node = Node(
+        package='foxglove_bridge',
+        executable='foxglove_bridge',
+        name='foxglove_bridge',
+        output='screen',
+        parameters=[{
+            'port': 8765,
+            'address': '0.0.0.0',
+            'topic_whitelist': ['.*'],
+            'service_whitelist': ['.*'],
+            'param_whitelist': ['.*'],
+            'send_buffer_limit': 10000000,
+            'use_compression': True
+        }]
+    )
+    
+    # Create launch description
+    ld = LaunchDescription()
+    ld.add_action(config_file_arg)
+    ld.add_action(host_sdk_node)
+    ld.add_action(pcd2depth_node)
+    ld.add_action(foxglove_bridge_node)
+    
+    return ld


### PR DESCRIPTION
### Description

This PR addresses the need for better visualization and debugging tools by adding a dedicated launch file for **Foxglove Studio** integration in ROS 2.

### Changes

- Added `launch_ROS2/odin1_foxglove.launch.py`:
  - Starts the main driver node (`host_sdk_sample`).
  - Starts the `pcd2depth_ros2_node` for converting pointclouds to depth images.
  - Starts the `foxglove_bridge` node to stream data to Foxglove Studio.

### Dependencies

- **Foxglove Bridge**: This launch file requires the foxglove bridge package to be installed on the system.

  ```bash
  sudo apt install ros-<distro>-foxglove-bridge
  # Example: sudo apt install ros-humble-foxglove-bridge
  ```

### How to Test

1. Compile the workspace:

   ```bash
   colcon build --symlink-install
   source install/setup.bash
   ```

2. Launch the driver with Foxglove support:

   ```bash
   ros2 launch odin_ros_driver odin1_foxglove.launch.py
   ```

3. Open Foxglove Studio and connect to `ws://localhost:8765`.