### PR TITLE
fix: support Ubuntu 24.04 ROS2 Jazzy build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ if(DEFINED BUILD_SYSTEM)
     set(ROS_VERSION ${BUILD_SYSTEM})
     message(STATUS "ROS_VERSION: ${ROS_VERSION}")
 elseif(DEFINED ENV{ROS_DISTRO})
-    if("$ENV{ROS_DISTRO}" MATCHES "foxy|galactic|humble|iron|rolling")
+    if("$ENV{ROS_DISTRO}" MATCHES "foxy|galactic|humble|iron|jazzy|rolling")
         set(ROS_VERSION "ROS2")
     else()
         set(ROS_VERSION "ROS1")
@@ -237,6 +237,7 @@ elseif(ROS_VERSION STREQUAL "ROS2")
     # Find all necessary ROS2 packages
     find_package(ament_cmake REQUIRED)
     find_package(rclcpp REQUIRED)
+    find_package(ament_index_cpp REQUIRED)
     find_package(std_msgs REQUIRED)
     find_package(sensor_msgs REQUIRED)
     find_package(nav_msgs REQUIRED)
@@ -267,7 +268,8 @@ elseif(ROS_VERSION STREQUAL "ROS2")
     
     # Add ROS2 dependencies
     ament_target_dependencies(host_sdk_sample
-        rclcpp 
+        rclcpp
+        ament_index_cpp
         std_msgs 
         sensor_msgs 
         nav_msgs 
@@ -406,6 +408,7 @@ elseif(ROS_VERSION STREQUAL "ROS2")
     ament_export_targets(export_${PROJECT_NAME})
     # Declare dependencies
     ament_export_dependencies(
+        ament_index_cpp
         rclcpp 
         std_msgs 
         sensor_msgs 
@@ -444,4 +447,3 @@ message(STATUS "Target platform: ${TARGET_PLATFORM}")
 message(STATUS "lydHostApi library: ${LYD_HOST_API_LIB}")
 message(STATUS "libusb library: ${LIBUSB_LIBRARIES}")
 message(STATUS "=======================================")
-

--- a/include/cv_bridge/cv_bridge.h
+++ b/include/cv_bridge/cv_bridge.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#if __has_include(<cv_bridge/cv_bridge.hpp>)
+#include <cv_bridge/cv_bridge.hpp>
+#else
+#include_next <cv_bridge/cv_bridge.h>
+#endif

--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <!-- ROS2 dependencies -->
   <depend>rclcpp</depend>
+  <depend>ament_index_cpp</depend>
   <!-- System dependencies -->
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>

--- a/package_ros2.xml
+++ b/package_ros2.xml
@@ -9,6 +9,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <!-- ROS2 dependencies -->
   <depend>rclcpp</depend>
+  <depend>ament_index_cpp</depend>
   <!-- System dependencies -->
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>

--- a/script/build_ros2.sh
+++ b/script/build_ros2.sh
@@ -65,15 +65,19 @@ build_workspace() {
     
     echo -e "${YELLOW}Starting ROS2 project build...${NC}"
 
-    cd $WS_DIR
+    cd "${WORKSPACE_ROOT}" || return 1
     rm -rf build install log
     # Ensure ROS2 environment is loaded
-    if [ -f "/opt/ros/foxy/setup.bash" ]; then
+    if [ -n "${ROS_DISTRO}" ] && [ -f "/opt/ros/${ROS_DISTRO}/setup.bash" ]; then
+        source "/opt/ros/${ROS_DISTRO}/setup.bash"
+    elif [ -f "/opt/ros/foxy/setup.bash" ]; then
         source "/opt/ros/foxy/setup.bash"
     elif [ -f "/opt/ros/galactic/setup.bash" ]; then
         source "/opt/ros/galactic/setup.bash"
     elif [ -f "/opt/ros/humble/setup.bash" ]; then
         source "/opt/ros/humble/setup.bash"
+    elif [ -f "/opt/ros/jazzy/setup.bash" ]; then
+        source "/opt/ros/jazzy/setup.bash"
     else
         echo -e "${RED}Could not find ROS2 setup.bash file. Please ensure ROS2 is installed.${NC}"
         return 1


### PR DESCRIPTION
## Summary
- detect ROS 2 Jazzy as a ROS2 build in CMake
- declare and export the ament_index_cpp dependency used by the ROS2 driver
- add a cv_bridge compatibility wrapper that uses the Jazzy .hpp header while falling back to the older .h header
- fix the ROS2 build script workspace directory and add Jazzy setup detection while preserving older distro order

## Validation
- ./script/build_ros2.sh succeeds on Ubuntu 24.04 / ROS 2 Jazzy
- Existing warnings are limited to PCL/pcap and pre-existing source warnings